### PR TITLE
Allow the user to select a model

### DIFF
--- a/wolverine.py
+++ b/wolverine.py
@@ -1,4 +1,3 @@
-import argparse
 import difflib
 import fire
 import json


### PR DESCRIPTION
- Implement argparse for handling command line options
- Add --model option to allow specifying the model name (default: gpt-4)
- Update send_error_to_gpt4 function to accept model_name as a parameter
- Rename send_error_to_gpt4 function to send_error_to_gpt