### PR TITLE
Access prompt.txt via relative path

### DIFF
--- a/wolverine.py
+++ b/wolverine.py
@@ -10,6 +10,8 @@ from termcolor import cprint
 from dotenv import load_dotenv
 
 
+FOLDER = os.path.realpath(os.path.dirname(__file__))
+
 # Set up the OpenAI API
 load_dotenv()
 openai.api_key = os.getenv("OPENAI_API_KEY")
@@ -17,7 +19,7 @@ openai.api_key = os.getenv("OPENAI_API_KEY")
 DEFAULT_MODEL = os.environ.get("DEFAULT_MODEL", "gpt-4")
 
 
-with open("prompt.txt") as f:
+with open(os.path.join(FOLDER, "prompt.txt")) as f:
     SYSTEM_PROMPT = f.read()
 
 


### PR DESCRIPTION
Imagine this folder structure:
```
$ tree
.
├── project
│   └── script.py
└── wolverine
    └── wolverine.py
```

I'd like to run `wolverine.py` from within my `project` folder. But I get:
```
$ python /tmp/wolverine/wolverine.py script.py
Traceback (most recent call last):
  File "/tmp/wolverine/wolverine.py", line 20, in <module>
    with open("prompt.txt") as f:
         ^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'prompt.txt'
```

The fix is to calculate the path to  `prompt.txt` relative to `wolverine.py`.

The allows running in the following way. 

```
cd project
python ../wolverine/wolverine.py script.py
```