### PR TITLE
Add RERUN_INTERVAL environment variable and show a countdown counter

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,2 +1,4 @@
 OPENAI_API_KEY=your_api_key
 #DEFAULT_MODEL=gpt-3.5-turbo
+# suggest using 20 since OpenAI API rate limit(3 / min)
+RERUN_INTERVAL=1


### PR DESCRIPTION
Add RERUN_INTERVAL environment variable and show a countdown counter before re-run script since OpenAI API has rate limit. And show total rounds counter when ran successfully.

here is the preview:
<img width="544" alt="Screenshot 2023-07-20 at 16 43 35" src="https://github.com/biobootloader/wolverine/assets/71397/a4422f1c-a1e2-4f83-b5fd-012c78b78ca1">
